### PR TITLE
feat: add step to workflow to publish docker image to docker registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,21 @@ jobs:
           REPO_NAME: "ccn-coverage-docker"
           TARGET_ARTIFACT_NAME: "ccn-coverage-api"
         run: npx semantic-release
+
+      - name: Get version
+        id: get_version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Released version: $VERSION"
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          registry: icr.infra.seattlecommunitynetwork.org
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and publish Docker image
+        run: |
+          make publish VERSION=${{ steps.get_version.outputs.VERSION }}

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,17 @@ build-%: validate-semver-%
 	@echo "Create docker container for $(API_DOCKER_IMAGE_NAME) with version $*"
 	docker build -t $(API_DOCKER_IMAGE_NAME):$* .
 
+# Publish to Docker registry (e.g., make publish VERSION=1.2.3)
+.PHONY: publish
+publish: validate-semver-$(VERSION)
+	@echo "Building and publishing $(API_DOCKER_IMAGE_NAME):$(VERSION)"
+	docker build -t $(API_DOCKER_IMAGE_NAME):$(VERSION) .
+	docker tag $(API_DOCKER_IMAGE_NAME):$(VERSION) icr.infra.seattlecommunitynetwork.org/$(API_DOCKER_IMAGE_NAME):$(VERSION)
+	docker tag $(API_DOCKER_IMAGE_NAME):$(VERSION) icr.infra.seattlecommunitynetwork.org/$(API_DOCKER_IMAGE_NAME):latest
+	docker push icr.infra.seattlecommunitynetwork.org/$(API_DOCKER_IMAGE_NAME):$(VERSION)
+	docker push icr.infra.seattlecommunitynetwork.org/$(API_DOCKER_IMAGE_NAME):latest
+	@echo "Successfully published $(API_DOCKER_IMAGE_NAME):$(VERSION) to registry"
+
 # The target for development
 .PHONY: dev
 dev:


### PR DESCRIPTION
These changes allow for the docker images from the following repositories to upload their containers to the SCN docker registry each time a new version is released: ccn-coverage-api, ccn-coverage-vis, ccn-coverage-backup-helper. Then, ccn-coverage-docker pulls these images from the registry instead of building them from scratch. 